### PR TITLE
[FEAT] 운동 좋아요(하트) 활성화/비활성화 API 구현 (#8)

### DIFF
--- a/planfit/build.gradle
+++ b/planfit/build.gradle
@@ -24,6 +24,7 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'org.postgresql', name: 'postgresql',version: '42.7.3'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
+++ b/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
@@ -7,12 +7,13 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class BaseResponse<T> {
-    private final int status;
+    private final HttpStatus status;
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private final T data;

--- a/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
+++ b/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
@@ -13,21 +13,21 @@ import org.springframework.http.HttpStatus;
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Getter
 public class BaseResponse<T> {
-    private final HttpStatus status;
+    private final int status;
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private final T data;
 
     public static BaseResponse<?> of(SuccessMessage successMessage) {
         return builder()
-                .status(successMessage.getStatus())
+                .status(successMessage.getStatus().value())
                 .message(successMessage.getMessage())
                 .build();
     }
 
     public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
         return builder()
-                .status(successMessage.getStatus())
+                .status(successMessage.getStatus().value())
                 .message(successMessage.getMessage())
                 .data(data)
                 .build();
@@ -35,7 +35,7 @@ public class BaseResponse<T> {
 
     public static BaseResponse<?> of(ErrorMessage errorMessage) {
         return builder()
-                .status(errorMessage.getStatus())
+                .status(errorMessage.getStatus().value())
                 .message(errorMessage.getMessage())
                 .build();
     }

--- a/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
@@ -11,6 +11,6 @@ public enum ErrorMessage {
 
     ;
 
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 }

--- a/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessMessage {
 
-    POST_EXERCISE_LIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 눌렀습니다."),
-    DELETE_EXERCISE_UNLIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 취소했습니다.")
+    EXERCISE_LIKE_POST_SUCCESS(HttpStatus.OK, "해당 운동 좋아요 등록에 성공했습니다."),
+    EXERCISE_DELETE_UNLIKE_SUCCESS(HttpStatus.OK, "해당 운동 좋아요 취소에 성공했습니다")
 
     ;
     private final HttpStatus status;

--- a/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
@@ -3,12 +3,15 @@ package com.planfit.server.common.message;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
 
 @Getter
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessMessage {
 
+    POST_EXERCISE_LIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 눌렀습니다.")
+
     ;
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 }

--- a/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessMessage {
 
-    POST_EXERCISE_LIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 눌렀습니다.")
+    POST_EXERCISE_LIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 눌렀습니다."),
+    DELETE_EXERCISE_UNLIKE_SUCCESS(HttpStatus.OK, "해당 운동에 좋아요를 취소했습니다.")
 
     ;
     private final HttpStatus status;

--- a/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
@@ -18,7 +18,7 @@ public class RoutineController {
 
     private final RoutineService routineService;
 
-    @PostMapping("/exercise/{exerciseId}/like")
+    @PatchMapping("/exercise/{exerciseId}/like")
     public ResponseEntity<BaseResponse<?>> postExerciseLike(@RequestHeader Long userId,
                                                             @PathVariable Long exerciseId) {
 
@@ -27,7 +27,7 @@ public class RoutineController {
         return ApiResponseUtil.success(SuccessMessage.EXERCISE_LIKE_POST_SUCCESS);
     }
 
-    @DeleteMapping("/exercise/{exerciseId}/unlike")
+    @PatchMapping("/exercise/{exerciseId}/unlike")
     public ResponseEntity<BaseResponse<?>> deleteExerciseLike(@RequestHeader Long userId,
                                                               @PathVariable Long exerciseId) {
 

--- a/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
@@ -24,7 +24,7 @@ public class RoutineController {
 
         routineService.postExerciseLike(userId, exerciseId);
 
-        return ApiResponseUtil.success(SuccessMessage.POST_EXERCISE_LIKE_SUCCESS);
+        return ApiResponseUtil.success(SuccessMessage.EXERCISE_LIKE_POST_SUCCESS);
     }
 
     @DeleteMapping("/exercise/{exerciseId}/unlike")
@@ -33,7 +33,6 @@ public class RoutineController {
 
         routineService.deleteExerciseLike(userId, exerciseId);
 
-        return ApiResponseUtil.success(SuccessMessage.DELETE_EXERCISE_UNLIKE_SUCCESS);
-
+        return ApiResponseUtil.success(SuccessMessage.EXERCISE_DELETE_UNLIKE_SUCCESS);
     }
 }

--- a/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
@@ -27,7 +27,7 @@ public class RoutineController {
         return ApiResponseUtil.success(SuccessMessage.POST_EXERCISE_LIKE_SUCCESS);
     }
 
-    @DeleteMapping("/exercise/unlike")
+    @DeleteMapping("/exercise/{exerciseId}/unlike")
     public ResponseEntity<BaseResponse<?>> deleteExerciseLike(@RequestHeader Long userId,
                                                               @PathVariable Long exerciseId) {
 

--- a/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
@@ -1,5 +1,6 @@
 package com.planfit.server.controller;
 
+import com.fasterxml.jackson.databind.ser.Serializers;
 import com.planfit.server.common.ApiResponseUtil;
 import com.planfit.server.common.BaseResponse;
 import com.planfit.server.common.message.SuccessMessage;
@@ -17,7 +18,7 @@ public class RoutineController {
 
     private final RoutineService routineService;
 
-    @PostMapping("/exercise/like")
+    @PostMapping("/exercise/{exerciseId}/like")
     public ResponseEntity<BaseResponse<?>> postExerciseLike(@RequestHeader Long userId,
                                                             @PathVariable Long exerciseId) {
 
@@ -26,4 +27,13 @@ public class RoutineController {
         return ApiResponseUtil.success(SuccessMessage.POST_EXERCISE_LIKE_SUCCESS);
     }
 
+    @DeleteMapping("/exercise/unlike")
+    public ResponseEntity<BaseResponse<?>> deleteExerciseLike(@RequestHeader Long userId,
+                                                              @PathVariable Long exerciseId) {
+
+        routineService.deleteExerciseLike(userId, exerciseId);
+
+        return ApiResponseUtil.success(SuccessMessage.DELETE_EXERCISE_UNLIKE_SUCCESS);
+
+    }
 }

--- a/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/RoutineController.java
@@ -1,0 +1,29 @@
+package com.planfit.server.controller;
+
+import com.planfit.server.common.ApiResponseUtil;
+import com.planfit.server.common.BaseResponse;
+import com.planfit.server.common.message.SuccessMessage;
+import com.planfit.server.domain.Exercise;
+import com.planfit.server.service.RoutineService;
+import lombok.RequiredArgsConstructor;
+import org.apache.coyote.Response;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1")
+public class RoutineController {
+
+    private final RoutineService routineService;
+
+    @PostMapping("/exercise/like")
+    public ResponseEntity<BaseResponse<?>> postExerciseLike(@RequestHeader Long userId,
+                                                            @PathVariable Long exerciseId) {
+
+        routineService.postExerciseLike(userId, exerciseId);
+
+        return ApiResponseUtil.success(SuccessMessage.POST_EXERCISE_LIKE_SUCCESS);
+    }
+
+}

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -23,4 +23,12 @@ public class Routine {
     @JoinColumn(name = "exercise_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Exercise exercise;
+
+    public void like() {
+        this.isLike = true;
+    }
+
+    public void unlike() {
+        this.isLike = false;
+    }
 }

--- a/planfit/src/main/java/com/planfit/server/repository/ExerciseRepository.java
+++ b/planfit/src/main/java/com/planfit/server/repository/ExerciseRepository.java
@@ -1,0 +1,7 @@
+package com.planfit.server.repository;
+
+import com.planfit.server.domain.Exercise;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExerciseRepository extends JpaRepository<Exercise, Long> {
+}

--- a/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
+++ b/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
@@ -1,0 +1,12 @@
+package com.planfit.server.repository;
+
+import com.planfit.server.domain.Exercise;
+import com.planfit.server.domain.Routine;
+import com.planfit.server.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RoutineRepository extends JpaRepository<Routine, Long> {
+    Optional<Routine> findByUserAndExercise(User user, Exercise exercise);
+}

--- a/planfit/src/main/java/com/planfit/server/repository/UserRepository.java
+++ b/planfit/src/main/java/com/planfit/server/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.planfit.server.repository;
+
+import com.planfit.server.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/planfit/src/main/java/com/planfit/server/service/RoutineService.java
+++ b/planfit/src/main/java/com/planfit/server/service/RoutineService.java
@@ -1,0 +1,46 @@
+package com.planfit.server.service;
+
+import com.planfit.server.domain.Exercise;
+import com.planfit.server.domain.Routine;
+import com.planfit.server.domain.User;
+import com.planfit.server.repository.ExerciseRepository;
+import com.planfit.server.repository.RoutineRepository;
+import com.planfit.server.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class RoutineService {
+
+    private final RoutineRepository routineRepository;
+    private final UserRepository userRepository;
+    private final ExerciseRepository exerciseRepository;
+
+
+    @Transactional
+    public void postExerciseLike(Long userId, Long exerciseId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+
+        Routine routine = getRoutine(user, exercise);
+        routine.like();
+        routineRepository.save(routine);
+    }
+
+    public Routine getRoutine(User user, Exercise exercise) {
+        return routineRepository.findByUserAndExercise(user, exercise).orElseThrow();
+    }
+
+    @Transactional
+    public void deleteExerciseLike(Long userId, Long exerciseId) {
+        User user = userRepository.findById(userId).orElseThrow();
+        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();
+
+        Routine routine = getRoutine(user, exercise);
+        routine.unlike();
+        routineRepository.save(routine);
+    }
+}


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #8 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- 운동 좋아요 추가 API (POST)
<img width="1200" alt="스크린샷 2024-05-15 17 04 42" src="https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-SERVER/assets/70939232/d8d58b67-82fa-473d-b49d-f78bfc65ae40">
- 운동 좋아요 취소 API (DELETE)
<img width="1200" alt="스크린샷 2024-05-15 17 05 00" src="https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-SERVER/assets/70939232/53cdd02c-92c5-46a3-8826-6adc8144b7b4">
## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->



- 현재 운동관련 api와 멤버 관련 api가 없어서 임의로 일단 바로 repository에서 검색했습니다. 
- 추후에 memberService와 exerciseService와 머지 된후, 각 서비스에서 찾아오는 메서드로 변경하겠습니다.
- 또한 예외처리또한 추후에 머지된 후에 추가하겠습니다.
```java
@Transactional
    public void postExerciseLike(Long userId, Long exerciseId) {
        User user = userRepository.findById(userId).orElseThrow();
        Exercise exercise = exerciseRepository.findById(exerciseId).orElseThrow();

        Routine routine = getRoutine(user, exercise);
        routine.like();
        routineRepository.save(routine);
    }
```

- Routine 도메인 안에 like, unlike 메서드 추가했습니다
```java
 public void like() {
        this.isLike = true;
    }

    public void unlike() {
        this.isLike = false;
    }
```




