### PR TITLE
[FEAT] 운동 리스트 순서변경 API 구현 (#13) 

### DIFF
--- a/planfit/build.gradle
+++ b/planfit/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	runtimeOnly 'org.postgresql:postgresql'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
 }
 
 tasks.named('test') {

--- a/planfit/src/main/java/com/planfit/server/common/ApiResponseUtil.java
+++ b/planfit/src/main/java/com/planfit/server/common/ApiResponseUtil.java
@@ -2,6 +2,7 @@ package com.planfit.server.common;
 
 import com.planfit.server.common.message.ErrorMessage;
 import com.planfit.server.common.message.SuccessMessage;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 public interface ApiResponseUtil {
@@ -17,6 +18,11 @@ public interface ApiResponseUtil {
 
     static ResponseEntity<BaseResponse<?>> failure(ErrorMessage errorMessage) {
         return ResponseEntity.status(errorMessage.getStatus())
+                .body(BaseResponse.of(errorMessage));
+    }
+
+        static ResponseEntity<BaseResponse<?>> validFailure(String errorMessage) {
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
                 .body(BaseResponse.of(errorMessage));
     }
 }

--- a/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
+++ b/planfit/src/main/java/com/planfit/server/common/BaseResponse.java
@@ -7,6 +7,7 @@ import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
 
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
@@ -19,14 +20,14 @@ public class BaseResponse<T> {
 
     public static BaseResponse<?> of(SuccessMessage successMessage) {
         return builder()
-                .status(successMessage.getStatus())
+                .status(successMessage.getStatus().value())
                 .message(successMessage.getMessage())
                 .build();
     }
 
     public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
         return builder()
-                .status(successMessage.getStatus())
+                .status(successMessage.getStatus().value())
                 .message(successMessage.getMessage())
                 .data(data)
                 .build();
@@ -34,8 +35,15 @@ public class BaseResponse<T> {
 
     public static BaseResponse<?> of(ErrorMessage errorMessage) {
         return builder()
-                .status(errorMessage.getStatus())
+                .status(errorMessage.getStatus().value())
                 .message(errorMessage.getMessage())
+                .build();
+    }
+
+        public static BaseResponse<?> of(String errorMessage) {
+        return builder()
+                .status(HttpStatus.BAD_REQUEST.value())
+                .message(errorMessage)
                 .build();
     }
 }

--- a/planfit/src/main/java/com/planfit/server/common/exception/NotFoundException.java
+++ b/planfit/src/main/java/com/planfit/server/common/exception/NotFoundException.java
@@ -1,0 +1,10 @@
+package com.planfit.server.common.exception;
+
+import com.planfit.server.common.message.ErrorMessage;
+
+public class NotFoundException extends PlanfitException {
+
+    public NotFoundException(ErrorMessage errorMessage) {
+        super(errorMessage);
+    }
+}

--- a/planfit/src/main/java/com/planfit/server/common/handler/GlobalExceptionHandler.java
+++ b/planfit/src/main/java/com/planfit/server/common/handler/GlobalExceptionHandler.java
@@ -3,9 +3,14 @@ package com.planfit.server.common.handler;
 import com.planfit.server.common.ApiResponseUtil;
 import com.planfit.server.common.BaseResponse;
 import com.planfit.server.common.exception.BadRequestException;
+import com.planfit.server.common.exception.NotFoundException;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.Objects;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -13,5 +18,15 @@ public class GlobalExceptionHandler {
     @ExceptionHandler(BadRequestException.class)
     protected ResponseEntity<BaseResponse<?>> handleBadRequestException(final BadRequestException e) {
         return ApiResponseUtil.failure(e.getErrorMessage());
+    }
+
+    @ExceptionHandler(NotFoundException.class)
+    protected ResponseEntity<BaseResponse<?>> handleNotFoundException(final NotFoundException e) {
+        return ApiResponseUtil.failure(e.getErrorMessage());
+    }
+
+    @ExceptionHandler(MethodArgumentNotValidException.class)
+    public ResponseEntity<BaseResponse<?>> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+        return ApiResponseUtil.validFailure(Objects.requireNonNull(e.getBindingResult().getFieldError()).getDefaultMessage());
     }
 }

--- a/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
@@ -9,10 +9,11 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorMessage {
 
-    EXERCISE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "운동리스트 조회에 실패했습니다."),
+    EXERCISE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "운동리스트 조회에 실패했습니다."),
+    EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 운동이 존재하지 않습니다.")
 
     ;
 
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 }

--- a/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
@@ -10,7 +10,8 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
 
     EXERCISE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "운동리스트 조회에 실패했습니다."),
-    EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 운동이 존재하지 않습니다.")
+    EXERCISE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 운동이 존재하지 않습니다."),
+    ROUTINE_NOT_FOUND(HttpStatus.NOT_FOUND, "해당되는 운동 루틴이 존재하지 않습니다.")
 
     ;
 

--- a/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
@@ -9,9 +9,10 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum SuccessMessage {
 
-    EXERCISES_FIND_SUCCESS(HttpStatus.OK.value(), "운동 리스트 조회에 성공했습니다.")
+    EXERCISES_FIND_SUCCESS(HttpStatus.OK, "운동 리스트 조회에 성공했습니다."),
+    EXERCISES_REORDER_SUCCESS(HttpStatus.OK, "운동 리스트 순서 변경에 성공했습니다.")
 
     ;
-    private final int status;
+    private final HttpStatus status;
     private final String message;
 }

--- a/planfit/src/main/java/com/planfit/server/controller/ExerciseController.java
+++ b/planfit/src/main/java/com/planfit/server/controller/ExerciseController.java
@@ -3,10 +3,16 @@ package com.planfit.server.controller;
 import com.planfit.server.common.ApiResponseUtil;
 import com.planfit.server.common.BaseResponse;
 import com.planfit.server.common.message.SuccessMessage;
+import com.planfit.server.dto.request.ExerciseReorderAllRequest;
+import com.planfit.server.dto.request.ExerciseReorderRequest;
 import com.planfit.server.service.ExerciseService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -21,4 +27,13 @@ public class ExerciseController {
 
         return ApiResponseUtil.success(SuccessMessage.EXERCISES_FIND_SUCCESS, exerciseService.findExercises(userId));
     }
+
+    //운동 리스트 순서 변경
+    @PutMapping("/exercises")
+    public ResponseEntity<BaseResponse<?>> exercisesReorder(@RequestHeader Long userId,
+                                                            @Valid @RequestBody ExerciseReorderAllRequest exercises) {
+        exerciseService.reorderExercises(userId, exercises.exercises());
+        return ApiResponseUtil.success(SuccessMessage.EXERCISES_REORDER_SUCCESS);
+    }
+
 }

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -26,4 +26,12 @@ public class Routine {
     @JoinColumn(name = "exercise_id")
     @ManyToOne(fetch = FetchType.LAZY)
     private Exercise exercise;
+
+    public void setTemporarySequence(int sequence) {
+        this.sequence = sequence;
+    }
+
+    public void updateSequence(int sequence) {
+        this.sequence = sequence;
+    }
 }

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -16,7 +16,7 @@ public class Routine {
 
     private boolean isLike;
 
-    @Column(name = "seq", unique = true)
+    @Column(name = "seq")
     private int sequence;
 
     @JoinColumn(name = "user_id")

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -27,10 +27,6 @@ public class Routine {
     @ManyToOne(fetch = FetchType.LAZY)
     private Exercise exercise;
 
-    public void setTemporarySequence(int sequence) {
-        this.sequence = sequence;
-    }
-
     public void updateSequence(int sequence) {
         this.sequence = sequence;
     }

--- a/planfit/src/main/java/com/planfit/server/dto/request/ExerciseReorderAllRequest.java
+++ b/planfit/src/main/java/com/planfit/server/dto/request/ExerciseReorderAllRequest.java
@@ -1,0 +1,11 @@
+package com.planfit.server.dto.request;
+
+import jakarta.validation.Valid;
+
+import java.util.List;
+
+public record ExerciseReorderAllRequest(
+
+        @Valid List<ExerciseReorderRequest> exercises
+) {
+}

--- a/planfit/src/main/java/com/planfit/server/dto/request/ExerciseReorderRequest.java
+++ b/planfit/src/main/java/com/planfit/server/dto/request/ExerciseReorderRequest.java
@@ -1,0 +1,14 @@
+package com.planfit.server.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+public record ExerciseReorderRequest(
+
+        @NotNull(message = "운동 ID는 필수 입력 사항입니다.")
+        Long id,
+
+        @Min(value = 0, message = "인덱스는 음수가 될 수 없습니다.")
+        int index
+) {
+}

--- a/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
+++ b/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
@@ -1,5 +1,6 @@
 package com.planfit.server.repository;
 
+import com.planfit.server.domain.Exercise;
 import com.planfit.server.domain.Routine;
 import com.planfit.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -13,5 +14,5 @@ public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllByUserId(Long userId);
 
-    Optional<Routine> findByExerciseIdAndUserId(Long id, Long id1);
+    Optional<Routine> findByExerciseAndUser(Exercise exercise1, User user);
 }

--- a/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
+++ b/planfit/src/main/java/com/planfit/server/repository/RoutineRepository.java
@@ -5,8 +5,13 @@ import com.planfit.server.domain.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface RoutineRepository extends JpaRepository<Routine, Long> {
 
     List<Routine> findAllByUserOrderBySequenceAsc(User user);
+
+    List<Routine> findAllByUserId(Long userId);
+
+    Optional<Routine> findByExerciseIdAndUserId(Long id, Long id1);
 }

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -38,7 +38,7 @@ public class ExerciseService {
         User user = userRepository.findById(userId).orElseThrow();
 
         //모든 운동의 sequence를 임시값으로 초기화
-        initializeRoutineSequences(userId);
+//        initializeRoutineSequences(userId);
 
         //새로운 순서로 업데이트
         updateRoutinesWithNewOrder(exercises, user);
@@ -48,15 +48,6 @@ public class ExerciseService {
     public Exercise getExercise(Long exerciseId) {
         return exerciseRepository.findById(exerciseId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.EXERCISE_NOT_FOUND));
-    }
-
-    private void initializeRoutineSequences(Long userId) {
-        User user = userRepository.findById(userId).orElseThrow();
-        List<Routine> routines = user.getRoutines();
-        int tempSequence = -1000;
-        for (Routine routine : routines) {
-            routine.updateSequence(tempSequence--);
-        }
     }
 
     private void updateRoutinesWithNewOrder(List<ExerciseReorderRequest> exercises, User user) {

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -1,12 +1,18 @@
 package com.planfit.server.service;
 
+import com.planfit.server.common.exception.NotFoundException;
+import com.planfit.server.common.message.ErrorMessage;
+import com.planfit.server.domain.Routine;
 import com.planfit.server.domain.User;
+import com.planfit.server.dto.request.ExerciseReorderRequest;
 import com.planfit.server.dto.response.ExerciseGetAllResponse;
 import com.planfit.server.repository.RoutineRepository;
 import com.planfit.server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -21,5 +27,28 @@ public class ExerciseService {
         User user = userRepository.findById(userId).orElseThrow();
 
         return ExerciseGetAllResponse.fromRoutines(routineRepository.findAllByUserOrderBySequenceAsc(user));
+    }
+
+    @Transactional
+    //운동 리스트 순서 변경
+    public void reorderExercises(Long userId, List<ExerciseReorderRequest> exercises) {
+        User user = userRepository.findById(userId).orElseThrow();
+
+        //모든 운동의 sequence를 임시값으로 초기화
+        List<Routine> routines = routineRepository.findAllByUserId(userId);
+        int tempSequence = -1000;
+        for (Routine routine : routines) {
+            routine.setTemporarySequence(tempSequence--);
+        }
+        routineRepository.saveAll(routines);
+
+        //새로운 순서로 업데이트
+        for (ExerciseReorderRequest exercise : exercises) {
+            Routine routine = routineRepository.findByExerciseIdAndUserId(exercise.id(), user.getId())
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.EXERCISE_NOT_FOUND));
+            routine.updateSequence(exercise.index());
+            routineRepository.save(routine);
+        }
+
     }
 }

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -51,10 +51,11 @@ public class ExerciseService {
     }
 
     private void initializeRoutineSequences(Long userId) {
-        List<Routine> routines = routineRepository.findAllByUserId(userId);
+        User user = userRepository.findById(userId).orElseThrow();
+        List<Routine> routines = user.getRoutines();
         int tempSequence = -1000;
         for (Routine routine : routines) {
-            routine.setTemporarySequence(tempSequence--);
+            routine.updateSequence(tempSequence--);
         }
     }
 

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -2,10 +2,12 @@ package com.planfit.server.service;
 
 import com.planfit.server.common.exception.NotFoundException;
 import com.planfit.server.common.message.ErrorMessage;
+import com.planfit.server.domain.Exercise;
 import com.planfit.server.domain.Routine;
 import com.planfit.server.domain.User;
 import com.planfit.server.dto.request.ExerciseReorderRequest;
 import com.planfit.server.dto.response.ExerciseGetAllResponse;
+import com.planfit.server.repository.ExerciseRepository;
 import com.planfit.server.repository.RoutineRepository;
 import com.planfit.server.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +23,7 @@ public class ExerciseService {
 
     private final UserRepository userRepository;
     private final RoutineRepository routineRepository;
+    private final ExerciseRepository exerciseRepository;
 
     //운동 리스트 조회
     public ExerciseGetAllResponse findExercises(Long userId) {
@@ -34,6 +37,10 @@ public class ExerciseService {
     public void reorderExercises(Long userId, List<ExerciseReorderRequest> exercises) {
         User user = userRepository.findById(userId).orElseThrow();
 
+        for (ExerciseReorderRequest exercise : exercises) {
+            getExercise(exercise.id());
+        }
+
         //모든 운동의 sequence를 임시값으로 초기화
         List<Routine> routines = routineRepository.findAllByUserId(userId);
         int tempSequence = -1000;
@@ -45,10 +52,15 @@ public class ExerciseService {
         //새로운 순서로 업데이트
         for (ExerciseReorderRequest exercise : exercises) {
             Routine routine = routineRepository.findByExerciseIdAndUserId(exercise.id(), user.getId())
-                    .orElseThrow(() -> new NotFoundException(ErrorMessage.EXERCISE_NOT_FOUND));
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.ROUTINE_NOT_FOUND));
             routine.updateSequence(exercise.index());
             routineRepository.save(routine);
         }
 
+    }
+
+    public Exercise getExercise(Long exerciseId) {
+        return exerciseRepository.findById(exerciseId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.EXERCISE_NOT_FOUND));
     }
 }

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -60,11 +60,11 @@ public class ExerciseService {
     }
 
     private void updateRoutinesWithNewOrder(List<ExerciseReorderRequest> exercises, User user) {
-        for (ExerciseReorderRequest request : exercises) {
+        exercises.stream().forEach(request -> {
             Exercise exercise = getExercise(request.id());
             Routine routine = routineRepository.findByExerciseAndUser(exercise, user)
                     .orElseThrow(() -> new NotFoundException(ErrorMessage.ROUTINE_NOT_FOUND));
             routine.updateSequence(request.index());
-        }
+        });
     }
 }

--- a/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
+++ b/planfit/src/main/java/com/planfit/server/service/ExerciseService.java
@@ -38,10 +38,10 @@ public class ExerciseService {
         User user = userRepository.findById(userId).orElseThrow();
 
         //모든 운동의 sequence를 임시값으로 초기화
-        List<Routine> routines = initializeRoutineSequences(userId);
+        initializeRoutineSequences(userId);
 
         //새로운 순서로 업데이트
-        updateRoutinesWithNewOrder(exercises, user, routines);
+        updateRoutinesWithNewOrder(exercises, user);
 
     }
 
@@ -50,23 +50,20 @@ public class ExerciseService {
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.EXERCISE_NOT_FOUND));
     }
 
-    private List<Routine> initializeRoutineSequences(Long userId) {
+    private void initializeRoutineSequences(Long userId) {
         List<Routine> routines = routineRepository.findAllByUserId(userId);
         int tempSequence = -1000;
         for (Routine routine : routines) {
             routine.setTemporarySequence(tempSequence--);
         }
-        routineRepository.saveAll(routines);
-        return routines;
     }
 
-    private void updateRoutinesWithNewOrder(List<ExerciseReorderRequest> exercises, User user, List<Routine> routines) {
+    private void updateRoutinesWithNewOrder(List<ExerciseReorderRequest> exercises, User user) {
         for (ExerciseReorderRequest request : exercises) {
             Exercise exercise = getExercise(request.id());
             Routine routine = routineRepository.findByExerciseAndUser(exercise, user)
                     .orElseThrow(() -> new NotFoundException(ErrorMessage.ROUTINE_NOT_FOUND));
             routine.updateSequence(request.index());
         }
-        routineRepository.saveAll(routines);
     }
 }


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #13

## 👷 **작업한 내용**
- 운동 리스트 순서변경 구현
- valid 추가 (id가 null인 경우, index가 음수인 경우)
- baseResponse 변경

<img width="974" alt="image" src="https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-SERVER/assets/113420297/9e61ce76-bb47-4d86-ba07-d4e1482651ea">

<img width="977" alt="image" src="https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-SERVER/assets/113420297/4c26eaea-b848-4ec9-958c-eeae12f8e12b">


## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->

https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-SERVER/blob/2f1fbcb9ab0a301f2dcc7adce4c6321b50f975a3/planfit/src/main/java/com/planfit/server/service/ExerciseService.java#L63-L71

여기서 
``` java
 Routine routine = routineRepository.findByExerciseAndUser(exercise, user)
                    .orElseThrow(() -> new NotFoundException(ErrorMessage.ROUTINE_NOT_FOUND));
```

이 부분은 나중에 머지된 후에 서비스 메서드로 변경하겠습니다!