### PR TITLE
[FEAT] JPA 엔티티 정의 수정(#16)

### DIFF
--- a/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/ErrorMessage.java
@@ -9,8 +9,8 @@ import org.springframework.http.HttpStatus;
 @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
 public enum ErrorMessage {
 
-    USER_NOT_FOUND(HttpStatus.NOT_FOUND.value(), "해당 사용자가 존재하지 않습니다."),
-    EXERCISE_BAD_REQUEST(HttpStatus.BAD_REQUEST.value(), "운동리스트 조회에 실패했습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "해당 사용자가 존재하지 않습니다."),
+    EXERCISE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "운동리스트 조회에 실패했습니다."),
     ;
 
     private final HttpStatus status;

--- a/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
+++ b/planfit/src/main/java/com/planfit/server/common/message/SuccessMessage.java
@@ -10,13 +10,13 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
     
     // user
-    USER_MAIN_GET_SUCCESS(HttpStatus.OK.value(), "회원의 메인 화면 조회가 완료되었습니다."),
-    USER_PUT_SUCCESS(HttpStatus.OK.value(), "회원 정보 수정이 완료되었습니다."),
+    USER_MAIN_GET_SUCCESS(HttpStatus.OK, "회원의 메인 화면 조회가 완료되었습니다."),
+    USER_PUT_SUCCESS(HttpStatus.OK, "회원 정보 수정이 완료되었습니다."),
 
     // exercise
     EXERCISE_LIKE_POST_SUCCESS(HttpStatus.OK, "해당 운동 좋아요 등록에 성공했습니다."),
-    EXERCISE_DELETE_UNLIKE_SUCCESS(HttpStatus.OK, "해당 운동 좋아요 취소에 성공했습니다")
-    EXERCISES_FIND_SUCCESS(HttpStatus.OK.value(), "운동 리스트 조회에 성공했습니다.")
+    EXERCISE_DELETE_UNLIKE_SUCCESS(HttpStatus.OK, "해당 운동 좋아요 취소에 성공했습니다"),
+    EXERCISES_FIND_SUCCESS(HttpStatus.OK, "운동 리스트 조회에 성공했습니다.")
     ;
   
     private final HttpStatus status;

--- a/planfit/src/main/java/com/planfit/server/domain/Exercise.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Exercise.java
@@ -24,6 +24,4 @@ public class Exercise {
 
     @OneToMany(mappedBy = "exercise")
     private List<Routine> routines = new ArrayList<>();
-    @OneToMany(mappedBy = "exercise")
-    private List<Set> sets = new ArrayList<>();
 }

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -32,4 +32,12 @@ public class Routine {
 
     @OneToMany(mappedBy = "routine")
     private List<Set> sets = new ArrayList<>();
+
+    public void like() {
+        this.isLike = true;
+    }
+
+    public void unlike() {
+        this.isLike = false;
+    }
 }

--- a/planfit/src/main/java/com/planfit/server/domain/Routine.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Routine.java
@@ -3,6 +3,9 @@ package com.planfit.server.domain;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Builder
@@ -27,11 +30,6 @@ public class Routine {
     @ManyToOne(fetch = FetchType.LAZY)
     private Exercise exercise;
 
-    public void like() {
-        this.isLike = true;
-    }
-
-    public void unlike() {
-        this.isLike = false;
-    }
+    @OneToMany(mappedBy = "routine")
+    private List<Set> sets = new ArrayList<>();
 }

--- a/planfit/src/main/java/com/planfit/server/domain/Set.java
+++ b/planfit/src/main/java/com/planfit/server/domain/Set.java
@@ -17,7 +17,7 @@ public class Set {
 
     private boolean isDone;
 
-    @JoinColumn(name = "exercise_id")
+    @JoinColumn(name = "routine_id")
     @ManyToOne(fetch = FetchType.LAZY)
-    private Exercise exercise;
+    private Routine routine;
 }

--- a/planfit/src/main/java/com/planfit/server/dto/response/ExerciseGetResponse.java
+++ b/planfit/src/main/java/com/planfit/server/dto/response/ExerciseGetResponse.java
@@ -19,7 +19,7 @@ public record ExerciseGetResponse(
                 .map(routine -> new ExerciseGetResponse(
                         routine.getId(),
                         routine.getExercise().getName(),
-                        routine.getExercise().getSets().size(),
+                        routine.getSets().size(),
                         routine.getExercise().getWeight(),
                         routine.getExercise().getTimes(),
                         routine.getSequence()


### PR DESCRIPTION
# 🔥*Pull requests*

## ⛳️ **작업한 브랜치**
- Resolved: #16 

## 👷 **작업한 내용**
<!-- 작업한 내용을 적어주세요. -->
- JPA엔티티 정의 수정했습니다. (Routine과 Set 1대 다)
- ErrorMessage, SuccessMessage  HTTP 상태 코드의 정수 값을 반환하는 대신 열거형 상수 자체를 반환하도록 수정했습니다.

## 🚨 참고 사항
<!-- 참고할 사항이 있다면 적어주세요. -->
